### PR TITLE
Feature oxid ee compatible

### DIFF
--- a/src/Oxrun/Application.php
+++ b/src/Oxrun/Application.php
@@ -8,7 +8,9 @@ use Oxrun\Helper\DatenbaseConnection;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Class Application
@@ -72,7 +74,6 @@ class Application extends BaseApplication
         return array(new HelpCommand(), new Custom\ListCommand());
     }
 
-
     /**
      * @return \Symfony\Component\Console\Input\InputDefinition
      */
@@ -80,16 +81,37 @@ class Application extends BaseApplication
     {
         $inputDefinition = parent::getDefaultInputDefinition();
 
-        $shopDirOption = new InputOption(
-            '--shopDir',
-            '',
-            InputOption::VALUE_OPTIONAL,
-            'Force oxid base dir. No auto detection'
+        $inputDefinition->addOption(
+            new InputOption(
+                '--shopDir',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'Force oxid base dir. No auto detection'
+            )
         );
-        $inputDefinition->addOption($shopDirOption);
+
+        $inputDefinition->addOption(
+            new InputOption(
+                '--shopId',
+                '-m',
+                InputOption::VALUE_OPTIONAL,
+                'Shop Id (EE Relevant)',
+                1
+            )
+        );
 
         return $inputDefinition;
     }
+
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        if (true === $input->hasParameterOption(['--shopId', '-m'])) {
+            $_GET['shp'] = $input->getParameterOption(['--shopId', '-m']);
+        }
+
+        return parent::doRun($input, $output);
+    }
+
 
     /**
      * Oxid bootstrap.php is loaded.

--- a/src/Oxrun/Command/Config/GetCommand.php
+++ b/src/Oxrun/Command/Config/GetCommand.php
@@ -27,7 +27,6 @@ class GetCommand extends Command implements \Oxrun\Command\EnableInterface
             ->setName('config:get')
             ->setDescription('Gets a config value')
             ->addArgument('variableName', InputArgument::REQUIRED, 'Variable name')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL, null)
             ->addOption('moduleId', null, InputOption::VALUE_OPTIONAL, '');
     }
 

--- a/src/Oxrun/Command/Config/SetCommand.php
+++ b/src/Oxrun/Command/Config/SetCommand.php
@@ -29,7 +29,6 @@ class SetCommand extends Command implements \Oxrun\Command\EnableInterface
             ->addArgument('variableName', InputArgument::REQUIRED, 'Variable name')
             ->addArgument('variableValue', InputArgument::REQUIRED, 'Variable value')
             ->addOption('variableType', null, InputOption::VALUE_REQUIRED, 'Variable type')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL, null)
             ->addOption('moduleId', null, InputOption::VALUE_OPTIONAL, '');
     }
 

--- a/src/Oxrun/Command/Config/ShopGetCommand.php
+++ b/src/Oxrun/Command/Config/ShopGetCommand.php
@@ -25,8 +25,7 @@ class ShopGetCommand extends Command implements \Oxrun\Command\EnableInterface
         $this
             ->setName('config:shop:get')
             ->setDescription('Sets a shop config value')
-            ->addArgument('variableName', InputArgument::REQUIRED, 'Variable name')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL, 'oxbaseshop', 'oxbaseshop');
+            ->addArgument('variableName', InputArgument::REQUIRED, 'Variable name');
     }
 
     /**
@@ -38,7 +37,7 @@ class ShopGetCommand extends Command implements \Oxrun\Command\EnableInterface
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         // Shop config
-        $oxShop = oxNew('oxShop');
+        $oxShop = oxNew(\OxidEsales\Eshop\Application\Model\Shop::class);
         $oxShop->load($input->getOption('shopId'));
         $varibaleValue = $oxShop->{'oxshops__' . $input->getArgument('variableName')}->value;
         $output->writeln("<info>Config {$input->getArgument('variableName')} has value $varibaleValue</info>");

--- a/src/Oxrun/Command/Config/ShopSetCommand.php
+++ b/src/Oxrun/Command/Config/ShopSetCommand.php
@@ -26,8 +26,7 @@ class ShopSetCommand extends Command implements \Oxrun\Command\EnableInterface
             ->setName('config:shop:set')
             ->setDescription('Sets a shop config value')
             ->addArgument('variableName', InputArgument::REQUIRED, 'Variable name')
-            ->addArgument('variableValue', InputArgument::REQUIRED, 'Variable value')
-            ->addOption('shopId', null, InputOption::VALUE_OPTIONAL, 'oxbaseshop', 'oxbaseshop');
+            ->addArgument('variableValue', InputArgument::REQUIRED, 'Variable value');
     }
 
     /**

--- a/src/Oxrun/Command/Oxid/ShopListCommand.php
+++ b/src/Oxrun/Command/Oxid/ShopListCommand.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tobi
+ * Date: 2019-02-20
+ * Time: 01:07
+ */
+
+namespace Oxrun\Command\Oxid;
+
+use Oxrun\Traits\NeedDatabase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class ShopListCommands
+ * @package Oxrun\Command\Misc
+ */
+class ShopListCommand extends Command implements \Oxrun\Command\EnableInterface
+{
+    use NeedDatabase;
+
+    protected function configure()
+    {
+        $this->setName('oxid:shops')
+            ->setDescription('Lists the shops');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $table = new Table($output);
+
+        /** @var \oxShopList $oxShopList */
+        $oxShopList = oxNew(\OxidEsales\Eshop\Application\Model\ShopList::class);
+        $oxShopList->getAll();
+
+        $isVerbose = $output->getVerbosity() & OutputInterface::VERBOSITY_VERBOSE ||
+                     $output->getVerbosity() & OutputInterface::VERBOSITY_VERY_VERBOSE ||
+                     $output->getVerbosity() & OutputInterface::VERBOSITY_DEBUG;
+
+        if ($isVerbose) {
+            $this->displayVerbose($oxShopList, $table);
+        } else {
+            $this->displayNormal($oxShopList, $table);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * @param $oxShopList
+     * @param Table $table
+     */
+    protected function displayNormal($oxShopList, Table $table)
+    {
+        $headers = [
+            'ShopId',
+            'Shop name',
+            'Active',
+            'Productive',
+            'Url',
+            'SEO active',
+        ];
+
+        $table->setHeaders($headers);
+
+        foreach ($oxShopList as $oxShop) {
+            $row = [
+                $oxShop->oxshops__oxid->rawValue,
+                $oxShop->oxshops__oxname->rawValue,
+                $oxShop->oxshops__oxactive->rawValue ? 'yes' : 'no',
+                $oxShop->oxshops__oxproductive->rawValue ? 'yes' : 'no',
+                $oxShop->oxshops__oxurl->rawValue,
+                $oxShop->oxshops__oxseoactive->rawValue ? 'yes' : 'no',
+            ];
+            $table->addRow($row);
+        }
+    }
+
+    /**
+     * @param \oxBase $oxShop
+     * @param Table $table
+     */
+    protected function displayVerbose($oxShopList, Table $table)
+    {
+        $headers = ['Field name'];
+        $row = [];
+
+        $fieldnames = $oxShopList[1]->getFieldNames();
+        foreach ($fieldnames as $fieldname) {
+            $row[$fieldname] = [$fieldname];
+        }
+
+        foreach ($oxShopList as $oxShop) {
+            $headers[] = "ShopId: " . $oxShop->getId();
+
+            foreach ($fieldnames as $fieldname) {
+                $row[$fieldname][] = $oxShop->getFieldData($fieldname);
+            }
+        }
+        $table->setHeaders($headers);
+        $table->addRows(array_values($row));
+    }
+}

--- a/tests/Oxrun/Command/Oxid/ShopListCommandTest.php
+++ b/tests/Oxrun/Command/Oxid/ShopListCommandTest.php
@@ -11,6 +11,7 @@ namespace Oxrun\Oxid;
 use Oxrun\Application;
 use Oxrun\Command\Oxid\ShopListCommand;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -37,4 +38,21 @@ class ShopListCommandTest extends TestCase
         $this->assertContains('OXID eShop', $display);
     }
 
+    public function testVerboseExecute()
+    {
+        $app = new Application();
+        $shopListCommand = new ShopListCommand();
+        $app->bootstrapOxid($shopListCommand->needDatabaseConnection());
+        $app->add($shopListCommand);
+
+        $command = $app->find('oxid:shops');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' =>'oxid:shops'], ['verbosity' => Output::VERBOSITY_VERBOSE]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertContains('oxactive', $display);
+        $this->assertContains('oxproductive', $display);
+        $this->assertContains('oxedition', $display);
+    }
 }

--- a/tests/Oxrun/CommandCollection/EnableAdapterTest.php
+++ b/tests/Oxrun/CommandCollection/EnableAdapterTest.php
@@ -102,9 +102,6 @@ class EnableAdapterTest extends TestCase
         $this->assertTrue($actual);
     }
 
-    /**
-     * @group active
-     */
     public function testOxrunCommandCheckWithDatabaseConnection()
     {
         //Arrange

--- a/tests/Oxrun/OptionShopIdTest.php
+++ b/tests/Oxrun/OptionShopIdTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tobi
+ * Date: 2019-02-20
+ * Time: 00:46
+ */
+
+namespace Oxrun\Command;
+
+use Oxrun\Application;
+use Oxrun\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class OptionShopIdTest
+ * @package Oxrun\Command
+ */
+class OptionShopIdTest extends TestCase
+{
+    public function testExecute()
+    {
+        $app = new Application();
+        $app->bootstrapOxid(false);
+
+        $command = $app->find('help');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertContains('-m, --shopId[=SHOPID]', $display);
+    }
+
+    public function testMarkShopWithId()
+    {
+        $app = new Application();
+        $app->bootstrapOxid(false);
+        $app->setAutoExit(false);
+
+        $input = new ArrayInput(['help', '--shopId' => '4']);
+        $output = new StreamOutput(fopen('php://memory', 'w', false));
+        $app->run($input, $output);
+
+        $this->assertArrayHasKey('shp', $_GET);
+        $this->assertEquals(4, $_GET['shp']);
+    }
+
+    protected function tearDown()
+    {
+        unset($_GET['shp']);
+        parent::tearDown();
+    }
+}

--- a/tests/Oxrun/Oxid/ShopListCommandTest.php
+++ b/tests/Oxrun/Oxid/ShopListCommandTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tobi
+ * Date: 2019-02-20
+ * Time: 01:33
+ */
+
+namespace Oxrun\Oxid;
+
+use Oxrun\Application;
+use Oxrun\Command\Oxid\ShopListCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Class ShopListCommandTest
+ * @package Oxrun\Oxid
+ */
+class ShopListCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        $app = new Application();
+        $shopListCommand = new ShopListCommand();
+        $app->bootstrapOxid($shopListCommand->needDatabaseConnection());
+        $app->add($shopListCommand);
+
+        $command = $app->find('oxid:shops');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $display = $commandTester->getDisplay();
+        $this->assertContains('ShopId', $display);
+        $this->assertContains('Shop name', $display);
+        $this->assertContains('OXID eShop', $display);
+    }
+
+}


### PR DESCRIPTION
With the option --shopId all commands can now be determined in which shop they are executed.

For example: `oxrun module:activate --shopid 2 oegdproptin` would activate the module `oegdproptin` only in Shop 2 Shop 1 it would still be disabled.
