### PR TITLE
Add missing installtion step: migrate. on docker start.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
         OXID_IDEBUG: 0
         OXID_ADMIN_PASSWORD: admin@local.oxrun
         OXID_ADMIN_USERNAME: oxrunpassword
-
+#        COMPOSER_AUTH: '{"http-basic": {"enterprise-edition.packages.oxid-esales.com": {"username": "XXXX", "password": "XXXX"}}}'
     oxid_db:
       image: mesa/oxid:db
       restart: always

--- a/docker/bin/installOxid.sh
+++ b/docker/bin/installOxid.sh
@@ -41,6 +41,9 @@ if [ ! -f "${DOCKER_DOCUMENT_ROOT}/config.inc.php" ]; then
     echo "Copy demo asset ...";
     ${install_dir}/vendor/bin/oe-eshop-demodata_install
 
+    echo "Oxid eshop migration ...";
+    ${install_dir}/vendor/bin/oe-eshop-doctrine_migration migrations:migrate
+
     echo "Create OXID views ...";
     oxrun view:update --shopDir ${DOCKER_DOCUMENT_ROOT}
 


### PR DESCRIPTION
If OXID Enterprise Edition was installed the migration step was missing