### PR TITLE
Remove default shopId value to run multi* commands for multishops

### DIFF
--- a/src/Oxrun/Application.php
+++ b/src/Oxrun/Application.php
@@ -95,8 +95,7 @@ class Application extends BaseApplication
                 '--shopId',
                 '-m',
                 InputOption::VALUE_OPTIONAL,
-                'Shop Id (EE Relevant)',
-                1
+                'Shop Id (EE Relevant)'
             )
         );
 

--- a/tests/Oxrun/Command/Module/ActivateCommandTest.php
+++ b/tests/Oxrun/Command/Module/ActivateCommandTest.php
@@ -20,7 +20,8 @@ class ActivateCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'module' => 'oepaypal'
+                'module' => 'oepaypal',
+                '--shopId' => 1
             )
         );
 
@@ -30,7 +31,8 @@ class ActivateCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'module' => 'oepaypal'
+                'module' => 'oepaypal',
+                '--shopId' => 1
             )
         );
 
@@ -41,7 +43,8 @@ class ActivateCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'module' => 'oepaypal'
+                'module' => 'oepaypal',
+                '--shopId' => 1
             )
         );
 
@@ -51,7 +54,8 @@ class ActivateCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'module' => 'not_and_existing_module'
+                'module' => 'not_and_existing_module',
+                '--shopId' => 1
             )
         );
 

--- a/tests/Oxrun/Command/Module/DeactivateCommandTest.php
+++ b/tests/Oxrun/Command/Module/DeactivateCommandTest.php
@@ -19,7 +19,8 @@ class DeactivateCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'module' => 'oepaypal'
+                'module' => 'oepaypal',
+                '--shopId' => 1
             )
         );
 

--- a/tests/Oxrun/Command/Module/ReloadCommandTest.php
+++ b/tests/Oxrun/Command/Module/ReloadCommandTest.php
@@ -35,6 +35,7 @@ class ReloadCommandTest extends TestCase
             array(
                 'command' => $command->getName(),
                 'module' => 'oepaypal',
+                '--shopId' => 1,
                 '--force'  => true
             )
         );


### PR DESCRIPTION
Remove the default shopId 1 to allow the multi* commands to run without shopId so that all defined subshops in the yaml files will be processed, e.g. all modules for all subshops 1 to 5 will be activated