### PR TITLE
Fix cache clearing failing on sCompileDir with trailing slash.

### DIFF
--- a/src/Oxrun/Command/Cache/ClearCommand.php
+++ b/src/Oxrun/Command/Cache/ClearCommand.php
@@ -95,7 +95,7 @@ class ClearCommand extends Command implements \Oxrun\Command\EnableInterface
      */
     protected function unixFastClear($compileDir)
     {
-        $compileDir = escapeshellarg($compileDir);
+        $compileDir = escapeshellarg(rtrim($compileDir, '/\\'));
         // Fast Process: Move folder and create new folder
         passthru("mv ${compileDir} ${compileDir}_old && mkdir -p ${compileDir}/smarty");
         // Low Process delete folder on slow HD


### PR DESCRIPTION
If `sCompileDir` is set to a path with a trailing slash, oxrun will on Linux try to move this directory into itself (specifically a subfolder `_old`).

This pull request is just a small change to allow `unixFastClear` to remove the trailing slash before running the actual renaming/removal process.

No test has been written for this specific change yet but if `config.inc.php` is edited to use a path with a trailing slash during the PHP tests this does not fail.