### PR TITLE
Bugfix/mysql arguments with special characters

### DIFF
--- a/src/Oxrun/Command/Database/DumpCommand.php
+++ b/src/Oxrun/Command/Database/DumpCommand.php
@@ -233,7 +233,7 @@ HELP;
 
         $dbPwd = \oxRegistry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = ' -p ' . escapeshellarg($dbPwd);
+            $dbPwd = ' -p' . escapeshellarg($dbPwd);
         }
 
         $utfMode = '';

--- a/src/Oxrun/Command/Database/DumpCommand.php
+++ b/src/Oxrun/Command/Database/DumpCommand.php
@@ -234,7 +234,7 @@ HELP;
 
         $dbPwd = \oxRegistry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = ' -p' . $dbPwd;
+            $dbPwd = ' -p ' . escapeshellarg($dbPwd);
         }
 
         $utfMode = '';

--- a/src/Oxrun/Command/Database/DumpCommand.php
+++ b/src/Oxrun/Command/Database/DumpCommand.php
@@ -176,8 +176,7 @@ HELP;
                 $tablesNoData = array_map('escapeshellarg', $tables);
                 $tablesNoData = implode(' ', $tablesNoData);
 
-                $commandOnlyTable = $this->getMysqlDumpCommand() . ' ' . $tablesNoData;
-                $commandOnlyTable = sprintf($commandOnlyTable, ' --no-data');
+                $commandOnlyTable = $this->getMysqlDumpCommand('--no-data') . ' ' . $tablesNoData;
                 if ($file) {
                     $commandOnlyTable .= " > $file";
                 }
@@ -191,8 +190,7 @@ HELP;
 
         $ignoreTables = implode(' ', $ignoreTables);
 
-        $commandTable = $this->getMysqlDumpCommand();
-        $commandTable = sprintf($commandTable, $ignoreTables);
+        $commandTable = $this->getMysqlDumpCommand($ignoreTables);
         if (!empty($explicatedTable)) {
             $explicatedTable = array_map('escapeshellarg', $explicatedTable);
             $commandTable .= implode(' ', $explicatedTable);
@@ -224,9 +222,10 @@ HELP;
     /**
      * Get the mysqldump cli command with user credentials.
      *
+     * @param string $arguments
      * @return string
      */
-    protected function getMysqlDumpCommand()
+    protected function getMysqlDumpCommand($arguments = '')
     {
         $dbHost = \oxRegistry::getConfig()->getConfigParam('dbHost');
         $dbUser = \oxRegistry::getConfig()->getConfigParam('dbUser');
@@ -250,8 +249,8 @@ HELP;
             ' --quick' .
             ' --opt' .
             ' --hex-blob' .
-            $utfMode .
-            ' %s ' . # argumment part
+            $utfMode . ' ' .
+            $arguments . ' ' .
             $dbName .
             ' '; # bash part
 

--- a/src/Oxrun/Command/Database/ImportCommand.php
+++ b/src/Oxrun/Command/Database/ImportCommand.php
@@ -51,7 +51,7 @@ HELP;
         // allow empty password
         $dbPwd = Registry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = '-p ' . escapeshellarg($dbPwd);
+            $dbPwd = '-p' . escapeshellarg($dbPwd);
         }
 
         $exec = sprintf(

--- a/src/Oxrun/Command/Database/ImportCommand.php
+++ b/src/Oxrun/Command/Database/ImportCommand.php
@@ -51,7 +51,7 @@ HELP;
         // allow empty password
         $dbPwd = Registry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = '-p' . $dbPwd;
+            $dbPwd = '-p ' . escapeshellarg($dbPwd);
         }
 
         $exec = sprintf(

--- a/src/Oxrun/Command/Database/QueryCommand.php
+++ b/src/Oxrun/Command/Database/QueryCommand.php
@@ -66,7 +66,7 @@ HELP;
         // allow empty password
         $dbPwd = \oxRegistry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = '-p' . $dbPwd;
+            $dbPwd = '-p ' . escapeshellarg($dbPwd);
         }
 
         $exec = sprintf(

--- a/src/Oxrun/Command/Database/QueryCommand.php
+++ b/src/Oxrun/Command/Database/QueryCommand.php
@@ -66,7 +66,7 @@ HELP;
         // allow empty password
         $dbPwd = \oxRegistry::getConfig()->getConfigParam('dbPwd');
         if (!empty($dbPwd)) {
-            $dbPwd = '-p ' . escapeshellarg($dbPwd);
+            $dbPwd = '-p' . escapeshellarg($dbPwd);
         }
 
         $exec = sprintf(


### PR DESCRIPTION
Complex passwords with special characters like % or & can cause console commands to be misinterpreted.

`mysqldump -uroot -host localhost -pacomplex&pwd test` `pwd` is interpreted as the following command because of the ampersand.
Error like: `sh: 1: pwd: not found`

`mysqldump -uroot -host localhost -pacomplex%! %s test` this string is unsuitable as a format (sprintf) because the first percent sign is also recognized as a placeholder.
Error like: `Unknown format specifier "!"`