### PR TITLE
escape database name to avoid syntax error

### DIFF
--- a/src/Oxrun/Command/Database/DumpCommand.php
+++ b/src/Oxrun/Command/Database/DumpCommand.php
@@ -129,7 +129,7 @@ HELP;
         $dbName = Registry::getConfig()->getConfigParam('dbName');
 
         if($input->getOption('ignoreViews')) {
-            $viewsResultArray = \oxDb::getDb()->getAll("SHOW FULL TABLES IN {$dbName} WHERE TABLE_TYPE LIKE 'VIEW'");
+            $viewsResultArray = \oxDb::getDb()->getAll("SHOW FULL TABLES IN `{$dbName}` WHERE TABLE_TYPE LIKE 'VIEW'");
             if (is_array($viewsResultArray)) {
                 foreach ($viewsResultArray as $sqlRow) {
                     $ignoreTables[] = $sqlRow[0];
@@ -302,17 +302,17 @@ HELP;
         }
 
         $whereIN = implode("', '", $whereIN);
-        $conditionsIN = "Tables_in_{$dbName} IN ('{$whereIN}')";
+        $conditionsIN = "`Tables_in_{$dbName}` IN ('{$whereIN}')";
 
         $conditionsLIKE = '';
         if (!empty($whereLIKE)) {
-            $template = " OR Tables_in_{$dbName} LIKE ('%s')";
+            $template = " OR `Tables_in_{$dbName}` LIKE ('%s')";
             foreach ($whereLIKE as $tablename) {
                 $conditionsLIKE .= sprintf($template, $tablename);
             }
         }
 
-        $sqlstament = "SHOW FULL TABLES IN {$dbName} WHERE $conditionsIN $conditionsLIKE";
+        $sqlstament = "SHOW FULL TABLES IN `{$dbName}` WHERE $conditionsIN $conditionsLIKE";
 
         $result = \oxDb::getDb()->getAll($sqlstament);
 

--- a/src/Oxrun/Command/Database/ListCommand.php
+++ b/src/Oxrun/Command/Database/ListCommand.php
@@ -99,17 +99,17 @@ HELP;
         }
 
         $whereIN = implode("', '", $whereIN);
-        $conditionsIN = "Tables_in_{$dbName} IN ('{$whereIN}')";
+        $conditionsIN = "`Tables_in_{$dbName}` IN ('{$whereIN}')";
 
         $conditionsLIKE = '';
         if (!empty($whereLIKE)) {
-            $template = " OR Tables_in_{$dbName} LIKE ('%s')";
+            $template = " OR `Tables_in_{$dbName}` LIKE ('%s')";
             foreach ($whereLIKE as $tablename) {
                 $conditionsLIKE .= sprintf($template, $tablename);
             }
         }
 
-        $sqlstament = "SHOW FULL TABLES IN {$dbName} WHERE $conditionsIN $conditionsLIKE";
+        $sqlstament = "SHOW FULL TABLES IN `{$dbName}` WHERE $conditionsIN $conditionsLIKE";
 
         $existsTable = DatabaseProvider::getDb()->getAll($sqlstament);
 


### PR DESCRIPTION
A syntax error can occur, for example, if the name contains a hyphen